### PR TITLE
Minor comment change to AboutInnerClasses.java

### DIFF
--- a/koans/src/intermediate/AboutInnerClasses.java
+++ b/koans/src/intermediate/AboutInnerClasses.java
@@ -40,7 +40,7 @@ public class AboutInnerClasses {
 	public void innerClassesInMethods() {
 		class MethodInnerClass {
 			int oneHundred() { return 100; }
-		}; // <- Why do you need a semicolon here?
+		}
 		assertEquals(new MethodInnerClass().oneHundred(), __);
 		// Where can you use this class?
 	}
@@ -72,7 +72,7 @@ public class AboutInnerClasses {
 	public void creatingAnonymousInnerClasses() {
 		AboutInnerClasses anonymous = new AboutInnerClasses() {
 			int theAnswer() { return 23; }
-		};
+		};// <- Why do you need a semicolon here?
 		assertEquals(anonymous.theAnswer(), __);
 	}
 	


### PR DESCRIPTION
Line 43 of AboutInnerClasses currently ends with a comment asking why the semicolon that terminates the MethodInnerClass definition block is required. However, it's not actually required here (though it obviously doesn't do any harm). The question is more appropriately asked at line 75, where it's required to terminate not the block, but the statement of which the block is part.
