### PR TITLE
Use uppercase type suffixes for long

### DIFF
--- a/koans/src/beginner/AboutPrimitives.java
+++ b/koans/src/beginner/AboutPrimitives.java
@@ -34,12 +34,12 @@ public class AboutPrimitives {
 
 	@Koan
 	public void wholeNumbersCanAlsoBeOfTypeLong() {
-		assertEquals(getType(1l), __);
+		assertEquals(getType(1L), __);
 	}
 
 	@Koan
 	public void primitivesOfTypeLongHaveAnObjectTypeLong() {
-		Object number = 1l;
+		Object number = 1L;
 		assertEquals(getType(number), __);
 	}
 


### PR DESCRIPTION
...avoids confusion between 1l and 11. 1L is more readable.
