### PR TITLE
Fix problem with ordering of Koans in AboutLambdas

### DIFF
--- a/koans/src/java8/AboutLambdas.java
+++ b/koans/src/java8/AboutLambdas.java
@@ -23,9 +23,9 @@ public class AboutLambdas {
     static String str = "";
 
     //lambda has access to "this"
-    Caps lambdaField = s -> this.toString();
+    Caps thisLambdaField = s -> this.toString();
     //lambda has access to object methods
-    Caps lambdaField2 = s -> toString();
+    Caps toStringLambdaField = s -> toString();
 
     @Koan
     public void verySimpleLambda() throws InterruptedException {
@@ -55,12 +55,12 @@ public class AboutLambdas {
 
     @Koan
     public void lambdaField() {
-        assertEquals(lambdaField.capitalize(""), __);
+        assertEquals(thisLambdaField.capitalize(""), __);
     }
 
     @Koan
     public void lambdaField2() {
-        assertEquals(lambdaField2.capitalize(""), __);
+        assertEquals(toStringLambdaField.capitalize(""), __);
     }
 
     @Koan


### PR DESCRIPTION
There are two Koans that jump to the front of the line and don't get executed in order like the rest.  The problem seems to be in the way they are named.

My best guess is that Java reflection is ordering them first because a member variable with the same name comes above it.  However, adding characters to the end of the name doesn't fix the problem, you have the change something else.

It's possible that this is a problem with Java reflection and there isn't anything else that can be done, but I suspect there might be a bug in the Koans library that could explain the odd behavior.  Fixing that could help avoid similar issues elsewhere.