### PR TITLE
Fix markdown so github displays header properly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-#Java Koans [![Build Status](https://travis-ci.org/matyb/java-koans.png?branch=master)](https://travis-ci.org/matyb/java-koans)
+# Java Koans 
+
+[![Build Status](https://travis-ci.org/matyb/java-koans.png?branch=master)](https://travis-ci.org/matyb/java-koans)
 
 Running Instructions:
 =====================


### PR DESCRIPTION
For whatever reason, the original markdown displays properly on Markdown Previewer websites but Github was displaying the header `#` symbol and not displaying the first header as a header, just text.