### PR TITLE
Possible fix for Issue 79 - use of assertNotSame.

### DIFF
--- a/koans/src/beginner/AboutAssertions.java
+++ b/koans/src/beginner/AboutAssertions.java
@@ -62,17 +62,25 @@ public class AboutAssertions {
 
     @Koan
     public void assertSameInstance() {
-        // Just because something is equal doesn't mean that it is the same.
-        // It's only the same if the reference is the same.
-        Object same = new Integer(1);
-        Object sameReference = __;
-        assertSame(same, sameReference);
+        Integer original = new Integer(1);
+        Integer same = original;
+        Integer different = new Integer(1);
+        // These are both equal to the original...
+        assertEquals(original, same);
+        assertEquals(original, different);
+        // ...but only one refers to the same instance as the original.
+        assertSame(original, __);
     }
 
     @Koan
     public void assertNotSameInstance() {
-        Integer same = new Integer(1);
-        Integer sameReference = same;
-        assertNotSame(same, sameReference);
+        Integer original = new Integer(1);
+        Integer same = original;
+        Integer different = new Integer(1);
+        // These are both equal to the original...
+        assertEquals(original, same);
+        assertEquals(original, different);
+        // ...but only one of them refers to a different instance.
+        assertNotSame(original, same);  // We want equal, but _not_ the same.
     }
 }


### PR DESCRIPTION
[Issue 79](https://github.com/matyb/java-koans/issues/79) questions the need for the `assertNotSameInstance` method in `AboutAssertions`, specifically the `aboutNotSame` assertion.

This is my attempt to make both the positive assertion in `assertSameInstance` and the negative assertion more clear (if much longer) by making them more similar, and by giving each an example of how equality is different from "sameness".

I'm still not sure it justifies the existence of `aboutNotSame`, which is used literally nowhere else.