### PR TITLE
Dangling else dangles again

### DIFF
--- a/koans/src/beginner/AboutConditionals.java
+++ b/koans/src/beginner/AboutConditionals.java
@@ -52,15 +52,31 @@ public class AboutConditionals {
         boolean secretBoolean = false;
         boolean otherBooleanCondition = true;
         // Ifs without curly braces are ugly and not recommended but still valid:
+        if (secretBoolean)
+            x++;
+            if (otherBooleanCondition)
+                x = 10;
+        else
+            x--;
+        // Where does this else belong to!?
+        assertEquals(x, __);
+    }
+
+    @Koan
+    public void ifAsIntended() {
+        int x = 1;
+        boolean secretBoolean = false;
+        boolean otherBooleanCondition = true;
         if (secretBoolean) {
             x++;
-        }
-        if (otherBooleanCondition) {
-            x = 10;
+            if (otherBooleanCondition) {
+                x = 10;
+            }
         } else {
             x--;
         }
-        // Where does this else belong to!?
+        // There are different opinions on where the curly braces go...
+        // But as long as you put them here. You avoid problems as seen above.
         assertEquals(x, __);
     }
 

--- a/koans/src/beginner/AboutConditionals.java
+++ b/koans/src/beginner/AboutConditionals.java
@@ -47,18 +47,17 @@ public class AboutConditionals {
 
     @Koan
     public void nestedIfsWithoutCurlysAreReallyMisleading() {
-        // Why are these ugly you ask? Well, try for yourself
         int x = 1;
         boolean secretBoolean = false;
         boolean otherBooleanCondition = true;
-        // Ifs without curly braces are ugly and not recommended but still valid:
+        // Curly braces after an "if" or "else" are not required...
         if (secretBoolean)
             x++;
             if (otherBooleanCondition)
                 x = 10;
         else
             x--;
-        // Where does this else belong to!?
+        // ...but they are recommended.
         assertEquals(x, __);
     }
 
@@ -67,6 +66,8 @@ public class AboutConditionals {
         int x = 1;
         boolean secretBoolean = false;
         boolean otherBooleanCondition = true;
+        // Adding curly braces avoids the "dangling else" problem seen
+        // above.
         if (secretBoolean) {
             x++;
             if (otherBooleanCondition) {
@@ -75,8 +76,6 @@ public class AboutConditionals {
         } else {
             x--;
         }
-        // There are different opinions on where the curly braces go...
-        // But as long as you put them here. You avoid problems as seen above.
         assertEquals(x, __);
     }
 


### PR DESCRIPTION
Restored separate `nestedIfsWithoutCurlysAreReallyMisleading` and `ifAsIntended` koans, which were [combined](https://github.com/matyb/java-koans/commit/aadbd555ec982fcf7980efcf7b9de5297a9fa468#diff-c4b0526165cc6a76155492c6b5e779e8L48) as part of pull request #59.  The conditional is once again misleading, as intended.  (See issue #84.)